### PR TITLE
spark/demo: support demo for kubernetes

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -35,6 +35,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Spark -->
         <dependency>
@@ -66,27 +71,51 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!-- maven 打包插件 -->
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <!-- MANIFEST.MF 中 Class-Path 加入前缀 -->
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <!-- jar 包不包含唯一版本标识 -->
+                            <useUniqueVersions>false</useUniqueVersions>
+                            <!-- 指定入口类 -->
+                            <mainClass>com.causes.spark.SparkApplication</mainClass>
+                        </manifest>
+                    </archive>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
                 </configuration>
             </plugin>
+
+            <!-- 拷贝依赖 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/spark/src/main/java/com/causes/spark/SparkApplication.java
+++ b/spark/src/main/java/com/causes/spark/SparkApplication.java
@@ -1,10 +1,13 @@
 package com.causes.spark;
 
+import com.causes.spark.demo.job.SparkJobService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
@@ -14,18 +17,16 @@ import java.util.stream.Collectors;
 @SpringBootApplication
 public class SparkApplication implements ApplicationRunner {
 
+  @Autowired
+  private SparkJobService sparkJobService;
+
   public static void main(String[] args) {
     SpringApplication.run(SparkApplication.class, args);
   }
 
   @Override
   public void run(ApplicationArguments args) throws Exception {
-    List<String> appArgs = args.getNonOptionArgs().stream().filter(arg -> arg.contains("app")).collect(Collectors.toList());
-    if (CollectionUtils.isEmpty(appArgs)) {
-      return;
-    }
-    String appType = appArgs.get(0).split("=")[1];
-    System.out.println(appType);
-    log.info("Running application method");
+    // TODO: 测试，暂时写死为 SparkPiJob
+    sparkJobService.run("SparkPiJob");
   }
 }

--- a/spark/src/main/java/com/causes/spark/demo/job/BaseSparkJob.java
+++ b/spark/src/main/java/com/causes/spark/demo/job/BaseSparkJob.java
@@ -1,0 +1,44 @@
+package com.causes.spark.demo.job;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public abstract class BaseSparkJob {
+
+  protected SparkSession spark;
+  protected JavaSparkContext jsc;
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  public void main(Map<String, Object> args) {
+    init(args);
+    beforeRun();
+    run(args);
+    afterRun();
+  }
+
+  protected void init(Map<String, Object> args) {
+    SparkSession.Builder builder = SparkSession.builder().master("local[*]").appName("spark");
+    // TODO: 其他配置
+    spark = builder.getOrCreate();
+    jsc = new JavaSparkContext(spark.sparkContext());
+  }
+
+  protected void beforeRun() {
+  }
+
+  protected abstract void run(Map<String, Object> args);
+
+  protected void afterRun() {
+    ConfigurableApplicationContext context = (ConfigurableApplicationContext) applicationContext;
+    context.close();
+  }
+}

--- a/spark/src/main/java/com/causes/spark/demo/job/SparkJobService.java
+++ b/spark/src/main/java/com/causes/spark/demo/job/SparkJobService.java
@@ -1,0 +1,18 @@
+package com.causes.spark.demo.job;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SparkJobService {
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  public void run(String app) {
+    BaseSparkJob sparkJob = applicationContext.getBean(StringUtils.uncapitalize(app), BaseSparkJob.class);
+    sparkJob.main(null);
+  }
+}

--- a/spark/src/main/java/com/causes/spark/demo/job/SparkPiJob.java
+++ b/spark/src/main/java/com/causes/spark/demo/job/SparkPiJob.java
@@ -1,0 +1,37 @@
+package com.causes.spark.demo.job;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class SparkPiJob extends BaseSparkJob {
+
+  @Override
+  protected void run(Map<String, Object> args) {
+    int slices = 2;
+    int n = 100000 * slices;
+    List<Integer> l = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      l.add(i);
+    }
+
+    JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
+
+    int count = dataSet.map(integer -> {
+      double x = Math.random() * 2 - 1;
+      double y = Math.random() * 2 - 1;
+      return (x * x + y * y <= 1) ? 1 : 0;
+    }).reduce((integer, integer2) -> integer + integer2);
+
+    System.out.println("Pi is roughly " + 4.0 * count / n);
+  }
+}

--- a/spark/src/main/java/com/causes/spark/demo/sparklauncher/BaseSparkJob.java
+++ b/spark/src/main/java/com/causes/spark/demo/sparklauncher/BaseSparkJob.java
@@ -1,9 +1,8 @@
-package com.causes.spark.demo;
+package com.causes.spark.demo.sparklauncher;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.launcher.SparkLauncher;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 import org.springframework.util.StreamUtils;
 
 import java.io.IOException;

--- a/spark/src/main/java/com/causes/spark/demo/sparklauncher/DemoController.java
+++ b/spark/src/main/java/com/causes/spark/demo/sparklauncher/DemoController.java
@@ -1,8 +1,7 @@
-package com.causes.spark.demo;
+package com.causes.spark.demo.sparklauncher;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 public class DemoController {
 
   @Autowired
-  @Qualifier("baseSparkJob")
   private BaseSparkJob baseSparkJob;
 
   @GetMapping

--- a/spark/src/main/java/com/causes/spark/demo/sparklauncher/SparkJobConfig.java
+++ b/spark/src/main/java/com/causes/spark/demo/sparklauncher/SparkJobConfig.java
@@ -1,4 +1,4 @@
-package com.causes.spark.demo;
+package com.causes.spark.demo.sparklauncher;
 
 import lombok.Data;
 


### PR DESCRIPTION
# 描述

## 背景

https://github.com/causes-wang/warehouse/discussions/4

## 概述

- 修改 `pom.xml`，去掉原有的 `SpringBoot` 打包插件，增加 maven 打包插件（`lib` 与启动类分开）。便于 `spark submit` 。
- 原有 `spark launcher` 接口移动到 `demo/sparklauncher` 包下。
- 增加 `demo/job`：
  - `BaseSparkJob.afterRun`：执行完 `SparkJob` 之后结束 `SpringBoot`。
  - `SparkPiJob` 复制自 spark 案例。
- 修改 `SparkApplication`，增加 `ApplicationRunner`，令 spring boot 启动后立刻调用一次 `SparkPiJob`。
